### PR TITLE
Fix .travis.yml to work without a test folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ perl6:
 install:
     - rakudobrew build-zef
     - zef --debug install .
-
+script:
+    - zef list --installed


### PR DESCRIPTION
For .travis.yml `script:` currently has a default that does not work if you have no test directory (see: https://github.com/travis-ci/travis-build/blob/ef82e82457f82c6518d090544bb533dc0faf0063/lib/travis/build/script/perl6.rb#L53)

This overrides the default `script:` commands